### PR TITLE
CID-8 | Modals 

### DIFF
--- a/Frontend/src/App.svelte
+++ b/Frontend/src/App.svelte
@@ -4,14 +4,15 @@
   import GroupsPage from './lib/pages/GroupsPage.svelte';
   import LocationsPage from './lib/pages/LocationsPage.svelte';
   import AdminSettingsPage from './lib/pages/AdminSettingsPage.svelte';
-  import PageHeader from './lib/PageHeader.svelte';
-  import Modal from './Modal.svelte';
+
 
   if(Appsettings.Built)
   {
     //Logic for when built by the function app
-  }
+  };
+
   
+  // The selected manager acts as a key select for the pages, ex pages["Users"] instatntiates UsersPage
   let selectedManager = 'Users';
   
   function changeManager(selected){
@@ -19,10 +20,6 @@
     selectedManager = selected;
   };
   
-  let showModal = false;
-
-
-  // The selected manager acts as a key select for the pages, ex pages["Users"] instatntiates UsersPage
   let pages = {
     "Users" : UsersPage,
     "Groups" : GroupsPage,
@@ -64,13 +61,7 @@
   
   <!-- RIGHT MAIN PAGE -->
   <div class="manage">
-      <PageHeader bind:showModal={showModal} selectedManager={selectedManager} currentUser={currentUser} />
-
       <svelte:component this={pages[selectedManager]} />
-
-      <Modal bind:showModal={showModal} selectedManager={selectedManager}> 
-
-      </Modal>
   </div>
 </main>
 

--- a/Frontend/src/Modal.svelte
+++ b/Frontend/src/Modal.svelte
@@ -1,22 +1,23 @@
 <script>
 	import AddGroupForm from "./lib/forms/AddGroupForm.svelte";
 	import AddLocationForm from "./lib/forms/AddLocationForm.svelte";
-	import AddUserForm from './lib/forms/AddUserForm.svelte';
-
-	export let showModal = false; 
-	export let selectedManager;
+	import AddUserForm from "./lib/forms/AddUserForm.svelte";
 
 
 	let dialog; // HTMLDialogElement
 	$: if (dialog && showModal) dialog.showModal();
 
-	let currentHeader;
-	
-	let forms = {
-		"Users" : AddUserForm,  
-		"Groups" : AddGroupForm,
-		"Locations & Access Points" : AddLocationForm
-	};
+
+	  //Modal
+	export let showModal = false;
+	export let selectedContent = "";
+
+	let modalContent = {
+			"Users" : AddUserForm,  
+			"Groups" : AddGroupForm,
+			"Locations & Access Points" : AddLocationForm
+		};
+
 </script>
 
 
@@ -33,14 +34,10 @@
 			<div class="modal-x">
 				<button on:click={() => (showModal = false)}> X </button>
 			</div>
-			<div>
-				<h2>
-					{currentHeader}
-					<hr />
-				</h2>
-				<!-- Add more to the forms in order to inject anything into a modal-->
-				<svelte:component this={forms[selectedManager]} bind:header={currentHeader}/>
-			</div>
+
+			<!-- !Slot in the content for the modal!-->
+			<svelte:component this={modalContent[selectedContent]}/>
+			
 		</div>
 	</dialog>
 {/if}
@@ -88,5 +85,10 @@
 		to {
 			opacity: 1;
 		}
+	}
+
+	button {
+		background-color: transparent;
+    	color: #929292;
 	}
 </style>

--- a/Frontend/src/app.css
+++ b/Frontend/src/app.css
@@ -68,10 +68,7 @@ button {
 button:hover {
   border-color: #646cff;
 }
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
+
 
 @media (prefers-color-scheme: light) {
   :root {
@@ -87,7 +84,7 @@ button:focus-visible {
 }
 
 .required-field::after {
-  content: " *";
+  content: "*";
   color: red;
   display: inline;
 }
@@ -289,11 +286,7 @@ button:focus-visible {
 
 
 
-
-
-
 /* Modal */
-
 .modal-buttons{
   display: flex;
   flex-direction: row;
@@ -323,7 +316,6 @@ button:focus-visible {
 
 
 /* Forms */
-
 .add-form{
   margin: 0 2vw;
   display: flex;
@@ -354,4 +346,15 @@ width: 100%;
 display: flex;
 justify-content: flex-end;
 flex-wrap: nowrap;
+}
+
+.create-new, .create-new:active, .create-new:focus{
+  background: none !important;
+  border: none !important;
+  padding: 0 !important;
+  color: #477eff;
+  cursor: pointer;
+}
+.create-new:active{
+  color: #749effbc;
 }

--- a/Frontend/src/app.css
+++ b/Frontend/src/app.css
@@ -1,3 +1,4 @@
+/* Universal */
 :root {
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
@@ -52,12 +53,6 @@ h1 {
   padding: 2em;
 }
 
-/* #app {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
-} */
 
 button {
   border-radius: 8px;
@@ -91,8 +86,13 @@ button:focus-visible {
   }
 }
 
-/* App */
+.required-field::after {
+  content: " *";
+  color: red;
+  display: inline;
+}
 
+/* App */
 .left-menu {
   width : 25%;
   display : flex;
@@ -305,12 +305,15 @@ button:focus-visible {
   color: white;
 }
 .modal-buttons .close{
-  background-color: #e3e3e6;
+  background-color:  #d5d5d5;
   color: black;
 }
 .modal-buttons button {
-  display: block;
-  margin-left: 2em;
+  height: 4vh;
+  margin-left: 1vw;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .modal-x{

--- a/Frontend/src/lib/PageHeader.svelte
+++ b/Frontend/src/lib/PageHeader.svelte
@@ -1,19 +1,29 @@
 <script>
-    export let selectedManager;
-    export let currentUser;
-    export let showModal;
+    import Modal from "../Modal.svelte";
+
+    export let currentPage;
+    export let showModal; 
+
+    let selectedContent;
+
+    export function handleCreate(newContent){
+        selectedContent = newContent;
+        showModal = true;
+
+        console.log("new selectedContent: ", selectedContent)
+    }
 </script>
 
 
 <header class="page-legend">
     <div class="header-across header-above">
-        <h2>Manage {selectedManager}</h2>
-        <div class="header-id">
+        <h2>Manage {currentPage}</h2>
+        <!-- <div class="header-id">
             <p>{currentUser.lastName}, {currentUser.firstName}</p>
             <button class="current-user-pic">
                 {currentUser.firstName[0]}{currentUser.lastName[0]}
             </button>
-        </div>
+        </div> -->
     </div>
     
     <div class=header-across>
@@ -24,4 +34,6 @@
         </div>
     </div>
 </header>
+
+<Modal bind:showModal={showModal} selectedContent={currentPage}/>
 

--- a/Frontend/src/lib/PageHeader.svelte
+++ b/Frontend/src/lib/PageHeader.svelte
@@ -2,16 +2,16 @@
     import Modal from "../Modal.svelte";
 
     export let currentPage;
-    export let showModal; 
+    let showModal; 
 
     let selectedContent;
 
-    export function handleCreate(newContent){
-        selectedContent = newContent;
-        showModal = true;
+    // export function handleCreate(newContent){
+    //     selectedContent = newContent;
+    //     showModal = true;
 
-        console.log("new selectedContent: ", selectedContent)
-    }
+    //     console.log("new selectedContent: ", selectedContent)
+    // }
 </script>
 
 

--- a/Frontend/src/lib/PageHeader.svelte
+++ b/Frontend/src/lib/PageHeader.svelte
@@ -5,13 +5,6 @@
     let showModal; 
 
     let selectedContent;
-
-    // export function handleCreate(newContent){
-    //     selectedContent = newContent;
-    //     showModal = true;
-
-    //     console.log("new selectedContent: ", selectedContent)
-    // }
 </script>
 
 

--- a/Frontend/src/lib/forms/AddGroupForm.svelte
+++ b/Frontend/src/lib/forms/AddGroupForm.svelte
@@ -8,9 +8,37 @@
     };
 </script>
 
-<form action="" method="POST" on:submit|preventDefault={handleSubmit} class="add-form"><!--  prevent default is used to stop the page from refresh -->
-    <label>
-        Name of Group
+<div>
+    <h2>
+        Create a Group
+        <hr />
+    </h2>
+
+    <form action="" method="POST" on:submit|preventDefault={handleSubmit} class="add-form"><!--  prevent default is used to stop the page from refresh -->
+        <p class="required-field">Group Name</p>
         <input type="text" placeholder="" bind:value={groupName}>
-    </label>
-</form>
+
+    </form>
+</div>
+
+
+<style>
+    input, select{
+        height: 3vh;
+        box-sizing: border-box;
+        border-radius: 5px;
+        border-width: 2px;
+        border-style: inset;
+        border-color: -internal-light-dark(rgb(118, 118, 118), rgb(133, 133, 133));
+        border-image: initial;
+    }
+
+    h2 {
+        margin: 0;
+    }
+
+    form > p{
+        margin: 0;
+        margin-top: 1.5em
+    }
+</style>

--- a/Frontend/src/lib/forms/AddGroupForm.svelte
+++ b/Frontend/src/lib/forms/AddGroupForm.svelte
@@ -17,7 +17,6 @@
     <form action="" method="POST" on:submit|preventDefault={handleSubmit} class="add-form"><!--  prevent default is used to stop the page from refresh -->
         <p class="required-field">Group Name</p>
         <input type="text" placeholder="" bind:value={groupName}>
-
     </form>
 </div>
 

--- a/Frontend/src/lib/forms/AddLocationForm.svelte
+++ b/Frontend/src/lib/forms/AddLocationForm.svelte
@@ -11,21 +11,49 @@
     };
 </script>
 
-<form action="" method="POST" on:submit|preventDefault={handleSubmit} class="add-form"><!--  prevent default is used to stop the page from refresh -->
-    <label>
-        Location
+<div>
+    <h2>
+        Create a Location or Access Point
+        <hr />
+    </h2>
+
+    <form action="" method="POST" on:submit|preventDefault={handleSubmit} class="add-form"><!--  prevent default is used to stop the page from refresh -->
+        
+        <p class="required-field">Location</p>
         <input type="text" placeholder="" bind:value={location}>
-    </label>
-    <label>
-        Address
+
+        <p class="required-field">Address</p>
         <input type="text" placeholder="" bind:value={address}>
-    </label>
-    <label>
-        Associated Group
-        <input type="text" placeholder="" bind:value={associatedGroup}>
-    </label>
-    <label>
-        Access Poitns
-        <input type="text" placeholder="" bind:value={accessPoints}>
-    </label>
-</form>
+
+        <label>
+            Associated Group
+            <input type="text" placeholder="" bind:value={associatedGroup}>
+        </label>
+
+        <label>
+            Access Poitns
+            <input type="text" placeholder="" bind:value={accessPoints}>
+        </label>
+    </form>
+</div>
+
+<style>
+    input, select{
+        height: 3vh;
+        box-sizing: border-box;
+        border-radius: 5px;
+        border-width: 2px;
+        border-style: inset;
+        border-color: -internal-light-dark(rgb(118, 118, 118), rgb(133, 133, 133));
+        border-image: initial;
+    }
+
+    h2 {
+        margin: 0;
+    }
+
+    form > p{
+        margin: 0;
+        margin-top: 1.5em
+    }
+</style>

--- a/Frontend/src/lib/forms/AddLocationForm.svelte
+++ b/Frontend/src/lib/forms/AddLocationForm.svelte
@@ -25,15 +25,12 @@
         <p class="required-field">Address</p>
         <input type="text" placeholder="" bind:value={address}>
 
-        <label>
-            Associated Group
-            <input type="text" placeholder="" bind:value={associatedGroup}>
-        </label>
-
-        <label>
-            Access Poitns
-            <input type="text" placeholder="" bind:value={accessPoints}>
-        </label>
+        <label for="associated-groups">Associated Group</label>
+        <input name="associated-groups" type="text" placeholder="" bind:value={associatedGroup}>
+        
+        <label for="access-points">Access Points</label>
+        <input name="access-points" type="text" placeholder="" bind:value={accessPoints}>
+        
     </form>
 </div>
 

--- a/Frontend/src/lib/forms/AddUserForm.svelte
+++ b/Frontend/src/lib/forms/AddUserForm.svelte
@@ -19,53 +19,83 @@
     let group = [];
 </script>
 
-
-<form action="" method="POST" on:submit|preventDefault={handleSubmit} class="add-form" ><!--  prevent default is used to stop the page from refresh -->
-    <label>
-        Title
-        <input type="text" placeholder="" bind:value={title}>
-    </label>
-
-    <label>
-        First Name
-        <input type="text" placeholder="" bind:value={firstName}>
-    </label>
+<div>
+    <h2>
+        Create a User
+        <hr />
+    </h2>
     
-    <label>
-        Last Name
+    <form action="" method="POST" on:submit|preventDefault={handleSubmit} class="add-form" ><!--  prevent default is used to stop the page from refresh -->
+        
+
+        <!-- Revisit labels, it seemed at default the label tags do not work with the required-field class -->
+        <p class="required-field">Title</p>
+        <input id={title} type="text" placeholder="" bind:value={title}>
+        
+        
+        <p class="required-field">First Name</p>
+        <input type="text" placeholder="" bind:value={firstName}>
+
+        <p class="required-field">Last Name</p>
         <input type="text" placeholder="" bind:value={lastName}>
-    </label>
 
-    <label>
-        Email Address
-        <input type="text" placeholder="" bind:value={email}>
-    </label>
+        
+        <p class="required-field">Email</p>
+        <input id={email} type="text" placeholder="" bind:value={email}>
+        
+        
+        <label>
+            Location(s)
+            <select bind:value={location}>
+                <option value="TEST 1">TEST</option>
+                <option value="TEST 2">TEST</option>
+                <option value="TEST 3">TEST</option>
+            </select>
+        </label>
+        <small>
+            <a>Create New</a>
+            <!-- Ask about if these are intended to be hrefs or on:clicks -->
+        </small>
+        
+        <label>
+            Group(s)
+            <select bind:value={group}>
+                <option value="TEST 1">TEST</option>
+                <option value="TEST 2">TEST</option>
+                <option value="TEST 3">TEST</option>
+            </select>
+        </label>
+        <small>
+            <a>Create New</a>
+        </small>
+        
+        <div class="modal-buttons">
+            <!-- svelte-ignore a11y-autofocus -->
+            <button class="close" autofocus on:click={closeModal}>Close</button>
+            <!-- svelte-ignore a11y-autofocus -->
+            <button class="save" on:click={handleSubmit}>Save</button> 
+        </div>
+    </form>
+</div>
 
-    <label>
-        Location(s)
-        <select bind:value={location}>
-            <option value="TEST 1">TEST</option>
-            <option value="TEST 2">TEST</option>
-            <option value="TEST 3">TEST</option>
-        </select>
-    </label>
-    <small>Create New</small>
+<style>
+    input, select{
+        height: 3vh;
+        box-sizing: border-box;
+        border-radius: 5px;
+        border-width: 2px;
+        border-style: inset;
+        border-color: -internal-light-dark(rgb(118, 118, 118), rgb(133, 133, 133));
+        border-image: initial;
+    }
 
-    <label>
-        Group(s)
-        <select bind:value={group}>
-            <option value="TEST 1">TEST</option>
-            <option value="TEST 2">TEST</option>
-            <option value="TEST 3">TEST</option>
-        </select>
-    </label>
-    <small>Create New</small>
+    h2 {
+        margin: 0;
+        
+    }
 
-    <div class="modal-buttons">
-        <!-- svelte-ignore a11y-autofocus -->
-        <button class="close" autofocus on:click={closeModal}>Close</button>
-        <!-- svelte-ignore a11y-autofocus -->
-        <button class="save" on:click={handleSubmit}>Save</button> 
-    </div>
-</form>
-
+    form > p{
+        margin: 0;
+        margin-top: 1.5em
+    }
+</style>

--- a/Frontend/src/lib/forms/AddUserForm.svelte
+++ b/Frontend/src/lib/forms/AddUserForm.svelte
@@ -2,7 +2,6 @@
     export const header = 'Create a New User';
     export let closeModal; 
 
-
     function handleSubmit() {
         console.log("Submitted");
         alert("Form saved!");
@@ -28,7 +27,6 @@
     <form action="" method="POST" on:submit|preventDefault={handleSubmit} class="add-form" ><!--  prevent default is used to stop the page from refresh -->
         
 
-        <!-- Revisit labels, it seemed at default the label tags do not work with the required-field class -->
         <p class="required-field">Title</p>
         <input id={title} type="text" placeholder="" bind:value={title}>
         
@@ -44,29 +42,26 @@
         <input id={email} type="text" placeholder="" bind:value={email}>
         
         
-        <label>
-            Location(s)
-            <select bind:value={location}>
-                <option value="TEST 1">TEST</option>
-                <option value="TEST 2">TEST</option>
-                <option value="TEST 3">TEST</option>
-            </select>
-        </label>
+        <label for="locations">Location(s)</label>
+        <select name="locations" bind:value={location}>
+            <option value="TEST 1">TEST</option>
+            <option value="TEST 2">TEST</option>
+            <option value="TEST 3">TEST</option>
+        </select>
+        
         <small>
-            <a>Create New</a>
-            <!-- Ask about if these are intended to be hrefs or on:clicks -->
+            <button class="create-new">Create New</button>
         </small>
         
-        <label>
-            Group(s)
-            <select bind:value={group}>
+        <label for="groups">Group(s)</label>
+            <select name="groups" bind:value={group}>
                 <option value="TEST 1">TEST</option>
                 <option value="TEST 2">TEST</option>
                 <option value="TEST 3">TEST</option>
             </select>
-        </label>
+        
         <small>
-            <a>Create New</a>
+            <button class="create-new">Create New</button>
         </small>
         
         <div class="modal-buttons">
@@ -98,4 +93,5 @@
         margin: 0;
         margin-top: 1.5em
     }
+
 </style>

--- a/Frontend/src/lib/pages/GroupsPage.svelte
+++ b/Frontend/src/lib/pages/GroupsPage.svelte
@@ -1,4 +1,8 @@
 <script>
+    import PageHeader from "../PageHeader.svelte";
+
+    export let showModal = false;
+
     let groups = [{
         "name" : "Web Application Team",
     }, 
@@ -9,6 +13,8 @@
 </script>
 
 <main>
+    <PageHeader bind:showModal = {showModal} currentPage = {"Groups"}/>
+
     <table class="data-table">
         <thead>
             <tr>

--- a/Frontend/src/lib/pages/GroupsPage.svelte
+++ b/Frontend/src/lib/pages/GroupsPage.svelte
@@ -13,7 +13,7 @@
 </script>
 
 <main>
-    <PageHeader bind:showModal = {showModal} currentPage = {"Groups"}/>
+    <PageHeader currentPage = {"Groups"}/>
 
     <table class="data-table">
         <thead>

--- a/Frontend/src/lib/pages/LocationsPage.svelte
+++ b/Frontend/src/lib/pages/LocationsPage.svelte
@@ -15,7 +15,7 @@
 </script>
 
 <main>
-    <PageHeader bind:showModal = {showModal} currentPage = {"Locations & Access Points"}/>
+    <PageHeader currentPage = {"Locations & Access Points"}/>
     
     <table class="data-table">
         <thead>

--- a/Frontend/src/lib/pages/LocationsPage.svelte
+++ b/Frontend/src/lib/pages/LocationsPage.svelte
@@ -1,4 +1,8 @@
 <script>
+    import PageHeader from "../PageHeader.svelte";
+
+    export let showModal = false;
+
     // api call? users will become a request -- title, group and location will likely take a numbered key
     let locations = [{
         "city" : "Milwaukee",
@@ -11,6 +15,8 @@
 </script>
 
 <main>
+    <PageHeader bind:showModal = {showModal} currentPage = {"Locations & Access Points"}/>
+    
     <table class="data-table">
         <thead>
             <tr>
@@ -43,4 +49,3 @@
         </tbody>
     </table>
 </main>
-

--- a/Frontend/src/lib/pages/UsersPage.svelte
+++ b/Frontend/src/lib/pages/UsersPage.svelte
@@ -1,9 +1,12 @@
 <!-- Users need: last name, firstname, location group, title -->
 
 <script>
+    import Modal from "../../Modal.svelte";
+    export let showModal; 
+
+
     import PageHeader from "../PageHeader.svelte";
 
-    export let showModal = false;
 
     // api call? users will become a request -- title, group and location will likely take a numbered key
     let users = [{
@@ -44,7 +47,7 @@
 
 
 <main>
-    <PageHeader bind:showModal = {showModal} currentPage = {"Users"}/>
+    <PageHeader currentPage = {"Users"}/>
 
     <table class="data-table">
         <thead>
@@ -92,3 +95,9 @@
     </table>
 </main>
 
+
+<!-- Below is an example that a modal can also be on a page, this will be kept for some time to reference later -->
+<!-- Additionally, this does not currently support multiple modals for one page. Consider a selection function of sorts to do so -->
+
+<!-- <button on:click={() => showModal = true} ></button>
+<Modal selectedContent={"Groups"} bind:showModal={showModal} /> -->

--- a/Frontend/src/lib/pages/UsersPage.svelte
+++ b/Frontend/src/lib/pages/UsersPage.svelte
@@ -1,6 +1,10 @@
 <!-- Users need: last name, firstname, location group, title -->
 
 <script>
+    import PageHeader from "../PageHeader.svelte";
+
+    export let showModal = false;
+
     // api call? users will become a request -- title, group and location will likely take a numbered key
     let users = [{
         "firstName" : "Chad",
@@ -40,7 +44,7 @@
 
 
 <main>
-
+    <PageHeader bind:showModal = {showModal} currentPage = {"Users"}/>
 
     <table class="data-table">
         <thead>


### PR DESCRIPTION
Added the ability for modals to take content (a form for example) and inject it in. This approach offers greater abstraction. More components can be created and then injected to provide any content. 

As a note PageHeader now instantiates on a page. This was decided so that Page specific content (search and the title for example) can be used more locally and easier. The hr line on the modal story is now on a form, as not all modals may take that design. Which is why the closing X was kept as the base content in a modal. 